### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ source MY_ENV/bin/activate
 
 #### 2. Install requirements
 ```bash
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
 #### 3. Start development server


### PR DESCRIPTION
Receiving this error if the `-r` is not specified:

```bash
pip install requirements.txt
ERROR: Could not find a version that satisfies the requirement requirements.txt (from versions: none)
HINT: You are attempting to install a package literally named "requirements.txt" (which cannot exist). Consider using the '-r' flag to install the packages listed in requirements.txt
ERROR: No matching distribution found for requirements.txt
```

Proving the flag fix the issue and installs the requirements